### PR TITLE
Grab editor name directly from manifest instead of CLI

### DIFF
--- a/cozy-app-publish.js
+++ b/cozy-app-publish.js
@@ -22,7 +22,6 @@ if (major < 6) {
 const program = new commander.Command(pkg.name)
   .version(pkg.version)
   .usage(`[options]`)
-  .option('--editor <editor-name>', 'the registry editor to publish as (required)')
   .option('--token <editor-token>', 'the registry token matching the provided editor (required)')
   .option('--space <space-name>', 'the registry space name to publish the application to (default __default__)')
   .option('--build-dir <path>', 'path fo the build directory relative to the current directory (default ./build)')
@@ -41,7 +40,6 @@ const program = new commander.Command(pkg.name)
   .parse(process.argv)
 
 publishApp({
-  editor: program.editor,
   token: program.token,
   buildDir: program.buildDir,
   buildUrl: program.buildUrl,
@@ -59,7 +57,6 @@ function publishApp (cliOptions) {
     console.log(`${colorize.bold('Travis')} ${colorize.blue('publish mode')}`)
     console.log()
     scripts.travis({
-      registryEditor: cliOptions.editor,
       registryToken: cliOptions.token,
       branchName: cliOptions.onBranch,
       buildDir: cliOptions.buildDir,
@@ -72,7 +69,6 @@ function publishApp (cliOptions) {
     console.log(`${colorize.bold('Manual')} ${colorize.blue('publish mode')}`)
     console.log()
     scripts.manual({
-      registryEditor: cliOptions.editor,
       registryToken: cliOptions.token,
       buildDir: cliOptions.buildDir,
       appBuildUrl: cliOptions.buildUrl,

--- a/lib/manual.js
+++ b/lib/manual.js
@@ -15,7 +15,6 @@ const {
 // override is used only for test to skip prompt (cf prompt.override)
 // finishCallback is for now only used for the test assertions
 function manualPublish ({
-  registryEditor,
   registryToken,
   buildDir = DEFAULT_BUILD_DIR,
   manualVersion,
@@ -24,11 +23,6 @@ function manualPublish ({
   appBuildUrl,
   verbose
 }, override, finishCallback) {
-  // registry editor (required)
-  if (!registryEditor) {
-    throw new Error('Registry editor is missing. Publishing failed.')
-  }
-
   // registry editor token (required)
   if (!registryToken) {
     throw new Error('Registry token is missing. Publishing failed.')
@@ -38,6 +32,12 @@ function manualPublish ({
   const appManifestObj = getManifestAsObject(
     path.join(fs.realpathSync(process.cwd()), buildDir)
   )
+
+  // registry editor (required)
+  const registryEditor = appManifestObj.editor
+  if (!registryEditor) {
+    throw new Error('Registry editor is missing in the manifest. Publishing failed.')
+  }
 
   // get application version to publish
   if (!manualVersion) {

--- a/lib/travis.js
+++ b/lib/travis.js
@@ -14,7 +14,6 @@ const {
 
 // finishCallback is for now only used for the test assertions
 function travisPublish ({
-  registryEditor,
   registryToken,
   buildDir = DEFAULT_BUILD_DIR,
   branchName = DEFAULT_BRANCH_NAME,
@@ -60,11 +59,6 @@ function travisPublish ({
     }
   }
 
-  // registry editor (required)
-  if (!registryEditor) {
-    throw new Error('Registry editor is missing. Publishing failed.')
-  }
-
   // registry editor token (required)
   registryToken = registryToken || REGISTRY_TOKEN
   if (!registryToken) {
@@ -75,6 +69,12 @@ function travisPublish ({
   const appManifestObj = getManifestAsObject(
     path.join(TRAVIS_BUILD_DIR, buildDir)
   )
+
+  // registry editor (required)
+  const registryEditor = appManifestObj.editor
+  if (!registryEditor) {
+    throw new Error('Registry editor is missing in the manifest. Publishing failed.')
+  }
 
   // get application version to publish
   let appVersion = ''

--- a/test/__snapshots__/manual.spec.js.snap
+++ b/test/__snapshots__/manual.spec.js.snap
@@ -2,8 +2,6 @@
 
 exports[`Manual publishing script should handle error message if the publishing is canceled by the user via the prompt 1`] = `"Publishing manually canceled."`;
 
-exports[`Manual publishing script should throw an error if the editor is missing 1`] = `"Registry editor is missing. Publishing failed."`;
-
 exports[`Manual publishing script should throw an error if the token is missing 1`] = `"Registry token is missing. Publishing failed."`;
 
 exports[`Manual publishing script should work correctly if expected options provided 1`] = `
@@ -12,7 +10,7 @@ Object {
   "appSlug": "mock-app",
   "appType": "webapp",
   "appVersion": "2.1.8-dev.12345",
-  "registryEditor": "cozy",
+  "registryEditor": "Cozy",
   "registryToken": "registryTokenForTest123",
   "registryUrl": "https://mock.registry.cc",
   "sha256Sum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -26,7 +24,7 @@ Object {
   "appSlug": "mock-app",
   "appType": "webapp",
   "appVersion": "2.1.8-dev.12345",
-  "registryEditor": "cozy",
+  "registryEditor": "Cozy",
   "registryToken": "registryTokenForTest123",
   "registryUrl": "https://mock.registry.cc",
   "sha256Sum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -40,7 +38,7 @@ Object {
   "appSlug": "mock-app",
   "appType": "webapp",
   "appVersion": "2.1.8-dev.12345",
-  "registryEditor": "cozy",
+  "registryEditor": "Cozy",
   "registryToken": "registryTokenForTest123",
   "registryUrl": "https://mock.registry.cc",
   "sha256Sum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",

--- a/test/__snapshots__/travis.spec.js.snap
+++ b/test/__snapshots__/travis.spec.js.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Travis publishing script should throw an error if the editor is missing 1`] = `"Registry editor is missing. Publishing failed."`;
-
 exports[`Travis publishing script should throw an error if the token is missing 1`] = `"Registry token is missing. Publishing failed."`;
 
 exports[`Travis publishing script should work correctly if Travis environment variable provided (no TRAVIS_TAG) 1`] = `
@@ -10,7 +8,7 @@ Object {
   "appSlug": "mock-app",
   "appType": "webapp",
   "appVersion": "2.1.8-dev.f4a98378271c17e91faa9e70a2718c34c04cfc27",
-  "registryEditor": "cozy",
+  "registryEditor": "Cozy",
   "registryToken": "registryTokenForTest123",
   "registryUrl": "https://apps-registry.cozycloud.cc",
   "sha256Sum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -24,7 +22,7 @@ Object {
   "appSlug": "mock-app",
   "appType": "webapp",
   "appVersion": "2.1.8-dev.f4a98378271c17e91faa9e70a2718c34c04cfc27",
-  "registryEditor": "cozy",
+  "registryEditor": "Cozy",
   "registryToken": "registryTokenForTest123",
   "registryUrl": "https://apps-registry.cozycloud.cc",
   "sha256Sum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -38,7 +36,7 @@ Object {
   "appSlug": "mock-app",
   "appType": "webapp",
   "appVersion": "2.1.8",
-  "registryEditor": "cozy",
+  "registryEditor": "Cozy",
   "registryToken": "registryTokenForTest123",
   "registryUrl": "https://apps-registry.cozycloud.cc",
   "sha256Sum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",

--- a/test/manual.spec.js
+++ b/test/manual.spec.js
@@ -15,13 +15,11 @@ jest.mock('../lib/publish', () => jest.fn((options, finishCallback) => {
 }))
 
 const commons = {
-  editor: 'cozy',
   token: 'registryTokenForTest123'
 }
 
-function getOptions (editor, token, buildDir) {
+function getOptions (token, buildDir) {
   const options = {
-    registryEditor: editor,
     registryToken: token,
     appBuildUrl: 'https://mock.getarchive.cc/12345.tar.gz',
     manualVersion: '2.1.8-dev.12345',
@@ -53,7 +51,7 @@ describe('Manual publishing script', () => {
   })
 
   it('should work correctly if expected options provided', (done) => {
-    manualScript(getOptions(commons.editor, commons.token, './build'), { confirm: 'yes' }, (error) => {
+    manualScript(getOptions(commons.token, './build'), { confirm: 'yes' }, (error) => {
       // we use done callback to avoid process.exit which will kill the jest process
       expect(error).toBeUndefined()
       expect(publishLib).toHaveBeenCalledTimes(1)
@@ -63,7 +61,7 @@ describe('Manual publishing script', () => {
   })
 
   it('should work correctly with default buildDir value "build"', (done) => {
-    manualScript(getOptions(commons.editor, commons.token), { confirm: 'yes' }, (error) => {
+    manualScript(getOptions(commons.token), { confirm: 'yes' }, (error) => {
       // we use done callback to avoid process.exit which will kill the jest process
       expect(error).toBeUndefined()
       expect(publishLib).toHaveBeenCalledTimes(1)
@@ -73,7 +71,7 @@ describe('Manual publishing script', () => {
   })
 
   it('should work correctly if no space name provided', (done) => {
-    const options = getOptions(commons.editor, commons.token)
+    const options = getOptions(commons.token)
     delete options.spaceName
     manualScript(options, { confirm: 'yes' }, (error) => {
       // we use done callback to avoid process.exit which will kill the jest process
@@ -85,7 +83,7 @@ describe('Manual publishing script', () => {
   })
 
   it('should handle error message if the publishing is canceled by the user via the prompt', (done) => {
-    manualScript(getOptions(commons.editor, commons.token), { confirm: 'no' }, (error) => {
+    manualScript(getOptions(commons.token), { confirm: 'no' }, (error) => {
       // we use done callback to avoid process.exit which will kill the jest process
       expect(error.message).toMatchSnapshot()
       expect(publishLib).toHaveBeenCalledTimes(0)
@@ -93,15 +91,9 @@ describe('Manual publishing script', () => {
     })
   })
 
-  it('should throw an error if the editor is missing', () => {
-    expect(() => manualScript(
-      getOptions(null, commons.token), jest.fn())
-    ).toThrowErrorMatchingSnapshot()
-  })
-
   it('should throw an error if the token is missing', () => {
     expect(() => manualScript(
-      getOptions(commons.editor, null), jest.fn())
+      getOptions(null), jest.fn())
     ).toThrowErrorMatchingSnapshot()
   })
 })

--- a/test/mockApp/build/manifest.webapp
+++ b/test/mockApp/build/manifest.webapp
@@ -1,5 +1,6 @@
 {
   "name": "Mock Application",
+  "editor": "Cozy",
   "version": "2.1.8",
   "slug": "mock-app",
   "type": "webapp"

--- a/test/travis.spec.js
+++ b/test/travis.spec.js
@@ -13,7 +13,6 @@ const commons = {
   token: 'registryTokenForTest123',
   slug: 'mock-app',
   commitHash: 'f4a98378271c17e91faa9e70a2718c34c04cfc27',
-  editor: 'cozy',
   branchName: 'build',
   buildDir: mockAppDir
 }
@@ -79,25 +78,14 @@ jest.doMock('../utils/getTravisVariables', () =>
     TRAVIS_COMMIT: commons.commitHash,
     TRAVIS_REPO_SLUG: commons.slug,
     // encrypted variables
-    REGISTRY_TOKEN: commons.token
-  }))
-  .mockImplementationOnce(() => ({
-    TRAVIS_PULL_REQUEST: 'false',
-    TRAVIS_BRANCH: 'build',
-    TRAVIS_BUILD_DIR: commons.buildDir,
-    TRAVIS_TAG: null,
-    TRAVIS_COMMIT: commons.commitHash,
-    TRAVIS_REPO_SLUG: commons.slug,
-    // encrypted variables
     REGISTRY_TOKEN: ''
   }))
 )
 
 const travisScript = require('../lib/travis')
 
-function getOptions (editor, branchName) {
+function getOptions (branchName) {
   const options = {
-    registryEditor: editor,
     branchName: branchName || 'build',
     spaceName: 'mock_space',
     travis: true
@@ -111,7 +99,7 @@ describe('Travis publishing script', () => {
   })
 
   it('should work correctly if Travis environment variable provided (no TRAVIS_TAG)', (done) => {
-    travisScript(getOptions(commons.editor), (error) => {
+    travisScript(getOptions(), (error) => {
       // we use done callback to avoid process.exit which will kill the jest process
       expect(error).toBeUndefined()
       expect(publishLib).toHaveBeenCalledTimes(1)
@@ -121,7 +109,7 @@ describe('Travis publishing script', () => {
   })
 
   it('should work correctly with TRAVIS_TAG', (done) => {
-    travisScript(getOptions(commons.editor), (error) => {
+    travisScript(getOptions(), (error) => {
       // we use done callback to avoid process.exit which will kill the jest process
       expect(error).toBeUndefined()
       expect(publishLib).toHaveBeenCalledTimes(1)
@@ -131,7 +119,7 @@ describe('Travis publishing script', () => {
   })
 
   it('should work correctly if no space name provided', (done) => {
-    const options = getOptions(commons.editor)
+    const options = getOptions()
     delete options.spaceName
     travisScript(options, (error) => {
       // we use done callback to avoid process.exit which will kill the jest process
@@ -143,7 +131,7 @@ describe('Travis publishing script', () => {
   })
 
   it('should handle correctly and not publish if it is the wrong branch', (done) => {
-    travisScript(getOptions(commons.editor), (error) => {
+    travisScript(getOptions(), (error) => {
       // we use done callback to avoid process.exit which will kill the jest process
       expect(error).toBeUndefined()
       expect(publishLib).toHaveBeenCalledTimes(0)
@@ -152,7 +140,7 @@ describe('Travis publishing script', () => {
   })
 
   it('should handle correctly and not publish if it is a pull request', (done) => {
-    travisScript(getOptions(commons.editor), (error) => {
+    travisScript(getOptions(), (error) => {
       // we use done callback to avoid process.exit which will kill the jest process
       expect(error).toBeUndefined()
       expect(publishLib).toHaveBeenCalledTimes(0)
@@ -160,15 +148,9 @@ describe('Travis publishing script', () => {
     })
   })
 
-  it('should throw an error if the editor is missing', () => {
-    expect(() => travisScript(
-      getOptions(null), jest.fn())
-    ).toThrowErrorMatchingSnapshot()
-  })
-
   it('should throw an error if the token is missing', () => {
     expect(() => travisScript(
-      getOptions(commons.editor), jest.fn())
+      getOptions(), jest.fn())
     ).toThrowErrorMatchingSnapshot()
   })
 })


### PR DESCRIPTION
Also remove the option since it is mandatory in the manifest for the registry for all cases.