### PR TITLE
Prefer an option to provided the correct build commit hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ Then, just publish it using the Travis CI workflow:
 ```
 # publish it, REGISTRY_TOKEN should be
 # encrypted and provided via Travis CI environment
+# BUILD_COMMIT is your last build commit hash (git rev-parse build)
 yarn cozy-app-publish \
 --token $REGISTRY_TOKEN
+--build-commit $BUILD_COMMIT
 ```
 
 ### Manual usage (not recommended)
@@ -68,7 +70,11 @@ The path to the build folder, relative to the current directory. Since the 'stan
 
 For now, the registry a build archive (.tar.gz file) from an external link to be used in the cozy-stack. In the travis script, this url is computed using the Github trick to get archives from a commit url. For the manual script, we have to provide it.
 
-##### `--manual-version <version>` (manual usage only)
+##### `--build-commit <commit-hash>`
+
+Using the `travis` mode, the archive tarball URL is computed using github and the build commit hash. If you are not on your build branch to publish, you can specify the correct build commit hash using this parameter.
+
+##### `--manual-version <version>` (required for manual usage only)
 
 In the manual mode, we don't have a way to compute the version like in the Travis mode for example. So we have to provide it using this option.
 

--- a/cozy-app-publish.js
+++ b/cozy-app-publish.js
@@ -31,6 +31,7 @@ const program = new commander.Command(pkg.name)
   .option('--space <space-name>', 'the registry space name to publish the application to (default __default__)')
   .option('--build-dir <relative-path>', 'path fo the build directory relative to the current directory (default ./build)')
   .option('--build-url <url>', 'URL of the application archive')
+  .option('--build-commit <commit-hash>', 'hash of the build commit matching the build archive to publish')
   .option('--manual-version <version>', 'publishing a specific version manually (must not be already published in the registry)')
   .option('--registry-url <url>', 'the registry URL to publish to a different one from the default URL')
   .option('--verbose', 'print additional logs')
@@ -46,6 +47,7 @@ publishApp({
   token: program.token,
   buildDir: program.buildDir,
   buildUrl: program.buildUrl,
+  buildCommit: program.buildCommit,
   manualVersion: program.manualVersion,
   registryUrl: program.registryUrl,
   space: program.space,
@@ -69,6 +71,7 @@ function publishApp (cliOptions) {
     scripts.travis({
       registryToken: cliOptions.token,
       buildDir: cliOptions.buildDir,
+      buildCommit: cliOptions.buildCommit,
       registryUrl: cliOptions.registryUrl,
       spaceName: cliOptions.space,
       verbose: cliOptions.verbose

--- a/lib/travis.js
+++ b/lib/travis.js
@@ -15,6 +15,7 @@ const {
 function travisPublish ({
   registryToken,
   buildDir = DEFAULT_BUILD_DIR,
+  buildCommit,
   registryUrl = DEFAULT_REGISTRY_URL,
   spaceName,
   verbose
@@ -25,9 +26,7 @@ function travisPublish ({
     TRAVIS_COMMIT,
     TRAVIS_REPO_SLUG,
     // encrypted variables
-    REGISTRY_TOKEN,
-    // custom
-    BUILD_COMMIT
+    REGISTRY_TOKEN
   } = getTravisVariables()
 
   // travis build directory
@@ -67,7 +66,7 @@ function travisPublish ({
   // for now, the registry needs an external URL
   let appBuildUrl = ''
   const githubUrl = `https://github.com/${TRAVIS_REPO_SLUG}/archive`
-  const buildHash = BUILD_COMMIT || TRAVIS_COMMIT
+  const buildHash = buildCommit || TRAVIS_COMMIT
   if (TRAVIS_TAG) {
     appBuildUrl = `${githubUrl}/${TRAVIS_TAG}.tar.gz`
   } else {

--- a/utils/getTravisVariables.js
+++ b/utils/getTravisVariables.js
@@ -8,9 +8,7 @@ function getTravisVariables () {
     TRAVIS_COMMIT: getEnv('TRAVIS_COMMIT'),
     TRAVIS_REPO_SLUG: getEnv('TRAVIS_REPO_SLUG'),
     // encrypted variables
-    REGISTRY_TOKEN: getEnv('REGISTRY_TOKEN'),
-    // custom
-    BUILD_COMMIT: getEnv('BUILD_COMMIT')
+    REGISTRY_TOKEN: getEnv('REGISTRY_TOKEN')
   }
 }
 


### PR DESCRIPTION
Be more explicit to avoid magical things 🎩 

```
 yarn cozy-app-publish \
 --token $REGISTRY_TOKEN
 --build-commit $BUILD_COMMIT
```