### PR TITLE
Handle prepublish hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,39 @@ Using the `travis` mode, the archive tarball URL is computed using github and th
 
 In the manual mode, we don't have a way to compute the version like in the Travis mode for example. So we have to provide it using this option.
 
+##### `--prepublish <script_path>`
+
+Specify custom prepublish hook to manage how the app archive is generated and uploaded. The script must export a asynchronous function wich have the following signature:
+```js
+module.exports = async ({
+  appBuildUrl,
+  appSlug,
+  appType,
+  appVersion,
+  buildCommit,
+  registryUrl,
+  registryEditor,
+  registryToken,
+  spaceName
+}) => {
+ // ...
+}
+```
+
+This function must return an object containing the same options given in parameter, which can have been updated. For example, you may specifiy a new appBuildUlr in the hook. Here's a description of the different options:
+
+|Options|Description|
+|-|-|
+| `appBuildUrl` | The url where the build can be retrieved. For example, `http://github.com/cozy/cozy-foo/archives/cozy-foo.tar.gz`|
+| `appSlug` | The slug of the application, as defined in the manifest. Should not be mutated |
+| `appType` | `webapp` or `konnector` |
+| `appVersion` | App version, as defined in the manifest. Should not be mutated. |
+| `buildCommit` | sha of the commit, should not be mutated. |
+| `registryUrl` | URL of the Cozy registry, should not be mutated. |
+| `registryEditor` | Editor as it appears in the Cozy registry. |
+| `registryToken` | Registry Token. See [registry documentation](https://docs.cozy.io/en/cozy-stack/registry-publish/). Should not be mutated. |
+| `spaceName` | Space name in the Cozy registry. |
+
 ##### `--registry-url <url>`
 
 The url of the registry, by default it will be https://staging-apps-registry.cozycloud.cc.

--- a/cozy-app-publish.js
+++ b/cozy-app-publish.js
@@ -33,6 +33,7 @@ const program = new commander.Command(pkg.name)
   .option('--build-url <url>', 'URL of the application archive')
   .option('--build-commit <commit-hash>', 'hash of the build commit matching the build archive to publish')
   .option('--manual-version <version>', 'publishing a specific version manually (must not be already published in the registry)')
+  .option('--prepublish <script-path>', 'Hook to process parameters just before publishing, typically to upload archive on custom host')
   .option('--registry-url <url>', 'the registry URL to publish to a different one from the default URL')
   .option('--verbose', 'print additional logs')
   .on('--help', () => {
@@ -49,6 +50,7 @@ publishApp({
   buildUrl: program.buildUrl,
   buildCommit: program.buildCommit,
   manualVersion: program.manualVersion,
+  prepublishHook: program.prepublish,
   registryUrl: program.registryUrl,
   space: program.space,
   verbose: program.verbose
@@ -73,6 +75,7 @@ function publishApp (cliOptions) {
       buildDir: cliOptions.buildDir,
       buildCommit: cliOptions.buildCommit,
       buildUrl: cliOptions.buildUrl,
+      prepublishHook: cliOptions.prepublishHook,
       registryUrl: cliOptions.registryUrl,
       spaceName: cliOptions.space,
       verbose: cliOptions.verbose
@@ -86,6 +89,7 @@ function publishApp (cliOptions) {
       buildDir: cliOptions.buildDir,
       appBuildUrl: cliOptions.buildUrl,
       manualVersion: cliOptions.manualVersion,
+      prepublishHook: cliOptions.prepublishHook,
       registryUrl: cliOptions.registryUrl,
       spaceName: cliOptions.space,
       verbose: cliOptions.verbose

--- a/lib/manual.js
+++ b/lib/manual.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const fs = require('fs-extra')
-const spawn = require('cross-spawn')
+const prepublish = require('./prepublish')
 const publish = require('./publish')
 const prompt = require('prompt')
 const colorize = require('../utils/colorize')
@@ -14,7 +14,9 @@ const {
 
 // override is used only for test to skip prompt (cf prompt.override)
 // finishCallback is for now only used for the test assertions
-function manualPublish ({
+async function manualPublish ({
+  buildCommit,
+  prepublishHook,
   registryToken,
   buildDir = DEFAULT_BUILD_DIR,
   manualVersion,
@@ -56,30 +58,6 @@ function manualPublish ({
     throw new Error('The --build-url option is required for the manual mode. Publishing failed.')
   }
 
-  // get the sha256 hash from the archive from the url
-  const shaSumProcess = spawn.sync(
-    'sh',
-    [
-      '-c',
-      `curl -sSL --fail "${appBuildUrl}" | shasum -a 256 | cut -d" " -f1`
-    ],
-    {
-      stdio: verbose ? 'inherit' : 'pipe'
-    }
-  )
-  // Note: if the Url don't return an archive or if 404 Not found,
-  // the shasum will be the one of the error message from the curl command
-  // so no error throwed here whatever the url is
-  if (shaSumProcess.status !== 0) {
-    throw new Error(`Error from archive shasum computing (${appBuildUrl}). Publishing failed.`)
-  }
-  // remove also the ending line break
-  const sha256Sum = shaSumProcess.stdout.toString().replace(/\r?\n|\r/g, '')
-
-  // publish the application on the registry
-  console.log(`Attempting to publish ${colorize.bold(appSlug)} (version ${colorize.bold(appVersion)}) from ${colorize.bold(appBuildUrl)} (sha256 ${colorize.bold(sha256Sum)}) to ${colorize.bold(registryUrl)} (space: ${spaceName || 'default one'})`)
-  console.log()
-
   const promptProperties = [
     {
       name: 'confirm',
@@ -93,6 +71,23 @@ function manualPublish ({
   // useful for testing
   if (override) prompt.override = override
 
+  const publishOptions = await prepublish({
+    buildCommit,
+    prepublishHook,
+    registryUrl,
+    registryEditor,
+    registryToken,
+    spaceName,
+    appSlug,
+    appVersion,
+    appBuildUrl,
+    appType
+  })
+
+  // ready publish the application on the registry
+  console.log(`Attempting to publish ${colorize.bold(publishOptions.appSlug)} (version ${colorize.bold(publishOptions.appVersion)}) from ${colorize.bold(publishOptions.appBuildUrl)} (sha256 ${colorize.bold(publishOptions.sha256Sum)}) to ${colorize.bold(publishOptions.registryUrl)} (space: ${publishOptions.spaceName || 'default one'})`)
+  console.log()
+
   prompt.start()
   prompt.message = colorize.bold('Confirmation:')
   prompt.delimiter = ' '
@@ -100,17 +95,7 @@ function manualPublish ({
     console.log()
     if (err) throw new Error(colorize.red(`prompt: ${err}`))
     if (received.confirm.match(/^y(es)?$/i)) {
-      publish({
-        registryUrl,
-        registryEditor,
-        registryToken,
-        spaceName,
-        appSlug,
-        appVersion,
-        appBuildUrl,
-        sha256Sum,
-        appType
-      }, finishCallback)
+      publish(publishOptions, finishCallback)
     } else {
       const cancelError = new Error('Publishing manually canceled.')
       console.log(colorize.red(cancelError.message))

--- a/lib/prepublish.js
+++ b/lib/prepublish.js
@@ -1,0 +1,105 @@
+const path = require('path')
+const spawn = require('cross-spawn')
+
+/**
+ * Returns only expected value, avoid data injection by hook
+ */
+const sanitize = (options) => {
+  const {
+    appBuildUrl,
+    appSlug,
+    appType,
+    appVersion,
+    buildCommit,
+    registryUrl,
+    registryEditor,
+    registryToken,
+    spaceName
+  } = options
+
+  return {
+    appBuildUrl,
+    appSlug,
+    appType,
+    appVersion,
+    buildCommit,
+    registryUrl,
+    registryEditor,
+    registryToken,
+    spaceName
+  }
+}
+
+/**
+ * Check if all expected options are defined
+ */
+const check = options => {
+  ;[
+    'appBuildUrl',
+    'appSlug',
+    'appType',
+    'appVersion',
+    'registryUrl',
+    'registryEditor',
+    'registryToken'
+  ].forEach(option => {
+    if (typeof options[option] === 'undefined') {
+      throw new Error(`${option} cannot be undefined`)
+    }
+  })
+
+  return options
+}
+
+const shasum = (options) => {
+  const { appBuildUrl, verbose } = options
+
+  // get the sha256 hash from the archive from the url
+  const shaSumProcess = spawn.sync(
+    'sh',
+    [
+      '-c',
+      `curl -sSL --fail "${appBuildUrl}" | shasum -a 256 | cut -d" " -f1`
+    ],
+    {
+      stdio: verbose ? 'inherit' : 'pipe'
+    }
+  )
+  // Note: if the Url don't return an archive or if 404 Not found,
+  // the shasum will be the one of the error message from the curl command
+  // so no error throwed here whatever the url is
+  if (shaSumProcess.status !== 0) {
+    throw new Error(`Error from archive shasum computing (${appBuildUrl}). Publishing failed.`)
+  }
+  // remove also the ending line break
+  options.sha256Sum = shaSumProcess.stdout.toString().replace(/\r?\n|\r/g, '')
+  return options
+}
+
+module.exports = async (options) => {
+  const { prepublishHook } = options
+
+  let prepublish
+  let prepublishOptions
+
+  if (prepublishHook) {
+    try {
+      prepublish = require(process.cwd() + '/' + prepublishHook)
+    } catch (error) {
+      console.error(`↳ ⚠️  Unable to load prepublish hook : ${error.message}`)
+      console.log('↳ ℹ️  Ignoring prepublish hook')
+    }
+  }
+
+  if (prepublish) {
+    console.log(`↳ ℹ️  Running prepublish hook ${prepublishHook}`)
+    try {
+      prepublishOptions = await prepublish(options)
+    } catch (error) {
+      console.error(`↳ ⚠️  An error occured in prepublish hook : ${error.message}`)
+      console.log('↳ ℹ️  Ignoring prepublish hook')
+    }
+  }
+
+  return shasum(check(sanitize(prepublishOptions || options)))
+}

--- a/lib/travis.js
+++ b/lib/travis.js
@@ -1,6 +1,6 @@
 const path = require('path')
-const spawn = require('cross-spawn')
 const publish = require('./publish')
+const prepublish = require('./prepublish')
 const colorize = require('../utils/colorize')
 const getManifestAsObject = require('../utils/getManifestAsObject')
 const getTravisVariables = require('../utils/getTravisVariables')
@@ -12,7 +12,8 @@ const {
 } = constants
 
 // finishCallback is for now only used for the test assertions
-function travisPublish ({
+async function travisPublish ({
+  prepublishHook,
   registryToken,
   buildDir = DEFAULT_BUILD_DIR,
   buildCommit,
@@ -79,29 +80,8 @@ function travisPublish ({
     appBuildUrl = `${githubUrl}/${buildHash}.tar.gz`
   }
 
-  // get the sha256 hash from the archive from the url
-  const shaSumProcess = spawn.sync(
-    'sh',
-    [
-      '-c',
-      `curl -sSL --fail "${appBuildUrl}" | shasum -a 256 | cut -d" " -f1`
-    ],
-    {
-      stdio: verbose ? 'inherit' : 'pipe'
-    }
-  )
-  // Note: if the Url don't return an archive or if 404 Not found,
-  // the shasum will be the one of the error message from the curl command
-  // so no error throwed here whatever the url is
-  if (shaSumProcess.status !== 0) {
-    throw new Error(`Archive not found from ${appBuildUrl} or shasum computing errored. Publishing failed.`)
-  }
-  const sha256Sum = shaSumProcess.stdout.toString().replace(/\r?\n|\r/g, '')
-
-  // publish the application on the registry
-  console.log(colorize.blue(`Publishing ${appSlug} (version ${appVersion}) from ${appBuildUrl} (${sha256Sum}) to ${registryUrl} (space: ${spaceName || 'default one'})`))
-
-  publish({
+  const publishOptions = await prepublish({
+    prepublishHook,
     registryUrl,
     registryEditor,
     registryToken,
@@ -109,9 +89,13 @@ function travisPublish ({
     appSlug,
     appVersion,
     appBuildUrl,
-    sha256Sum,
     appType
-  }, finishCallback)
+  })
+
+  // publish the application on the registry
+  console.log(colorize.blue(`Publishing ${publishOptions.appSlug} (version ${publishOptions.appVersion}) from ${publishOptions.appBuildUrl} (${publishOptions.sha256Sum}) to ${publishOptions.registryUrl} (space: ${publishOptions.spaceName || 'default one'})`))
+
+  publish(publishOptions, finishCallback)
 }
 
 module.exports = travisPublish

--- a/test/__mocks__/prepublish-errored-hook.js
+++ b/test/__mocks__/prepublish-errored-hook.js
@@ -1,0 +1,3 @@
+module.exports = options => {
+  throw new Error('Hook error')
+}

--- a/test/__mocks__/prepublish-hook.js
+++ b/test/__mocks__/prepublish-hook.js
@@ -1,0 +1,3 @@
+module.exports = options => {
+  return Object.assign({}, options, { appBuildUrl: 'http://cozy.io'})
+}

--- a/test/__mocks__/prepublish-missing-options-hook.js
+++ b/test/__mocks__/prepublish-missing-options-hook.js
@@ -1,0 +1,5 @@
+module.exports = options => {
+  return {
+    appBuildUrl: 'http://cozy.io'
+  }
+}

--- a/test/__mocks__/prepublish-unsanitized-hook.js
+++ b/test/__mocks__/prepublish-unsanitized-hook.js
@@ -1,0 +1,3 @@
+module.exports = options => {
+  return Object.assign({}, options, { shouldnotbehere: 'no', nothingtodohere: true, cpatchane: 'nice' })
+}

--- a/test/__snapshots__/manual.spec.js.snap
+++ b/test/__snapshots__/manual.spec.js.snap
@@ -10,10 +10,12 @@ Object {
   "appSlug": "mock-app",
   "appType": "webapp",
   "appVersion": "2.1.8-dev.12345",
+  "buildCommit": undefined,
+  "prepublishHook": undefined,
   "registryEditor": "Cozy",
   "registryToken": "registryTokenForTest123",
   "registryUrl": "https://mock.registry.cc",
-  "sha256Sum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "sha256Sum": "fakeshasum5644545",
   "spaceName": "mock_space",
 }
 `;
@@ -24,10 +26,12 @@ Object {
   "appSlug": "mock-app",
   "appType": "webapp",
   "appVersion": "2.1.8-dev.12345",
+  "buildCommit": undefined,
+  "prepublishHook": undefined,
   "registryEditor": "Cozy",
   "registryToken": "registryTokenForTest123",
   "registryUrl": "https://mock.registry.cc",
-  "sha256Sum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "sha256Sum": "fakeshasum5644545",
   "spaceName": undefined,
 }
 `;
@@ -38,10 +42,12 @@ Object {
   "appSlug": "mock-app",
   "appType": "webapp",
   "appVersion": "2.1.8-dev.12345",
+  "buildCommit": undefined,
+  "prepublishHook": undefined,
   "registryEditor": "Cozy",
   "registryToken": "registryTokenForTest123",
   "registryUrl": "https://mock.registry.cc",
-  "sha256Sum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "sha256Sum": "fakeshasum5644545",
   "spaceName": "mock_space",
 }
 `;

--- a/test/__snapshots__/prepublish.spec.js.snap
+++ b/test/__snapshots__/prepublish.spec.js.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Prepublish script check for undefined mandatory options 1`] = `"appSlug cannot be undefined"`;
+
+exports[`Prepublish script generates sha256 1`] = `
+Object {
+  "appBuildUrl": "http://example.com",
+  "appSlug": "cozy-mock",
+  "appType": "webapp",
+  "appVersion": "0.0.1",
+  "buildCommit": undefined,
+  "registryEditor": "Cozy",
+  "registryToken": "a5464f54e654c6546b54a56a",
+  "registryUrl": "http://registry.mock/",
+  "sha256Sum": "3587cb776ce0e4e8237f215800b7dffba0f25865cb84550e87ea8bbac838c423",
+  "spaceName": undefined,
+}
+`;
+
+exports[`Prepublish script handles prepublish hook 1`] = `
+Object {
+  "appBuildUrl": "http://cozy.io",
+  "appSlug": "cozy-mock",
+  "appType": "webapp",
+  "appVersion": "0.0.1",
+  "buildCommit": undefined,
+  "registryEditor": "Cozy",
+  "registryToken": "a5464f54e654c6546b54a56a",
+  "registryUrl": "http://registry.mock/",
+  "sha256Sum": "67ebd36d450fe0382f97f296c1ee23d80463bd35dd9618a398307ad6509ba59d",
+  "spaceName": undefined,
+}
+`;
+
+exports[`Prepublish script ignores invalid prepublish hook path 1`] = `
+Object {
+  "appBuildUrl": "http://example.com",
+  "appSlug": "cozy-mock",
+  "appType": "webapp",
+  "appVersion": "0.0.1",
+  "buildCommit": undefined,
+  "registryEditor": "Cozy",
+  "registryToken": "a5464f54e654c6546b54a56a",
+  "registryUrl": "http://registry.mock/",
+  "sha256Sum": "3587cb776ce0e4e8237f215800b7dffba0f25865cb84550e87ea8bbac838c423",
+  "spaceName": undefined,
+}
+`;
+
+exports[`Prepublish script ignores prepublish hook thrown error 1`] = `
+Object {
+  "appBuildUrl": "http://example.com",
+  "appSlug": "cozy-mock",
+  "appType": "webapp",
+  "appVersion": "0.0.1",
+  "buildCommit": undefined,
+  "registryEditor": "Cozy",
+  "registryToken": "a5464f54e654c6546b54a56a",
+  "registryUrl": "http://registry.mock/",
+  "sha256Sum": "3587cb776ce0e4e8237f215800b7dffba0f25865cb84550e87ea8bbac838c423",
+  "spaceName": undefined,
+}
+`;
+
+exports[`Prepublish script sanitize options from hook script 1`] = `
+Object {
+  "appBuildUrl": "http://example.com",
+  "appSlug": "cozy-mock",
+  "appType": "webapp",
+  "appVersion": "0.0.1",
+  "buildCommit": undefined,
+  "registryEditor": "Cozy",
+  "registryToken": "a5464f54e654c6546b54a56a",
+  "registryUrl": "http://registry.mock/",
+  "sha256Sum": "3587cb776ce0e4e8237f215800b7dffba0f25865cb84550e87ea8bbac838c423",
+  "spaceName": undefined,
+}
+`;

--- a/test/__snapshots__/travis.spec.js.snap
+++ b/test/__snapshots__/travis.spec.js.snap
@@ -8,10 +8,11 @@ Object {
   "appSlug": "mock-app",
   "appType": "webapp",
   "appVersion": "2.1.8",
+  "prepublishHook": undefined,
   "registryEditor": "Cozy",
   "registryToken": "registryTokenForTest123",
   "registryUrl": "https://apps-registry.cozycloud.cc",
-  "sha256Sum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "sha256Sum": "fakeshasum5644545",
   "spaceName": "mock_space",
 }
 `;
@@ -22,10 +23,11 @@ Object {
   "appSlug": "mock-app",
   "appType": "webapp",
   "appVersion": "2.1.8-dev.f4a98378271c17e91faa9e70a2718c34c04cfc27",
+  "prepublishHook": undefined,
   "registryEditor": "Cozy",
   "registryToken": "registryTokenForTest123",
   "registryUrl": "https://apps-registry.cozycloud.cc",
-  "sha256Sum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "sha256Sum": "fakeshasum5644545",
   "spaceName": "mock_space",
 }
 `;
@@ -36,10 +38,11 @@ Object {
   "appSlug": "mock-app",
   "appType": "webapp",
   "appVersion": "2.1.8-dev.f4a98378271c17e91faa9e70a2718c34c04cfc27",
+  "prepublishHook": undefined,
   "registryEditor": "Cozy",
   "registryToken": "registryTokenForTest123",
   "registryUrl": "https://apps-registry.cozycloud.cc",
-  "sha256Sum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "sha256Sum": "fakeshasum5644545",
   "spaceName": undefined,
 }
 `;
@@ -50,10 +53,11 @@ Object {
   "appSlug": "mock-app",
   "appType": "webapp",
   "appVersion": "2.1.8",
+  "prepublishHook": undefined,
   "registryEditor": "Cozy",
   "registryToken": "registryTokenForTest123",
   "registryUrl": "https://apps-registry.cozycloud.cc",
-  "sha256Sum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "sha256Sum": "fakeshasum5644545",
   "spaceName": "mock_space",
 }
 `;

--- a/test/manual.spec.js
+++ b/test/manual.spec.js
@@ -4,6 +4,7 @@ const path = require('path')
 
 const manualScript = require('../lib/manual')
 const publishLib = require('../lib/publish')
+const prepublishLib = require('../lib/prepublish')
 
 const rootPath = process.cwd()
 const testFolder = '.tmp_test'
@@ -13,6 +14,8 @@ const mockAppDir = path.join(__dirname, 'mockApp')
 jest.mock('../lib/publish', () => jest.fn((options, finishCallback) => {
   finishCallback()
 }))
+
+jest.mock('../lib/prepublish', () => jest.fn(options => (Object.assign({}, options, { sha256Sum: 'fakeshasum5644545'}) )))
 
 const commons = {
   token: 'registryTokenForTest123'
@@ -91,9 +94,9 @@ describe('Manual publishing script', () => {
     })
   })
 
-  it('should throw an error if the token is missing', () => {
-    expect(() => manualScript(
+  it('should throw an error if the token is missing', async () => {
+    await expect(manualScript(
       getOptions(null), jest.fn())
-    ).toThrowErrorMatchingSnapshot()
+    ).rejects.toThrowErrorMatchingSnapshot()
   })
 })

--- a/test/prepublish.spec.js
+++ b/test/prepublish.spec.js
@@ -1,0 +1,47 @@
+/* eslint-env jest */
+const prepublishLib = require('../lib/prepublish')
+
+describe('Prepublish script', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const optionsMock = {
+    appBuildUrl: 'http://example.com',
+    appSlug: 'cozy-mock',
+    appType: 'webapp',
+    appVersion: '0.0.1',
+    registryUrl: 'http://registry.mock/',
+    registryEditor: 'Cozy',
+    registryToken: 'a5464f54e654c6546b54a56a'
+  }
+
+  it('generates sha256', async () => {
+    await expect(prepublishLib(optionsMock)).resolves.toMatchSnapshot()
+  })
+
+  it('handles prepublish hook', async () => {
+    const options = { ...optionsMock, prepublishHook: './test/__mocks__/prepublish-hook' }
+    await expect(prepublishLib(options)).resolves.toMatchSnapshot()
+  })
+
+  it('ignores invalid prepublish hook path', async () => {
+    const options = { ...optionsMock, prepublishHook: './test/__mocks__/not-existing-hook' }
+    await expect(prepublishLib(options)).resolves.toMatchSnapshot()
+  })
+
+  it('ignores prepublish hook thrown error', async () => {
+    const options = { ...optionsMock, prepublishHook: './test/__mocks__/prepublish-errored-hook' }
+    await expect(prepublishLib(options)).resolves.toMatchSnapshot()
+  })
+
+  it('sanitize options from hook script', async () => {
+    const options = { ...optionsMock, prepublishHook: './test/__mocks__/prepublish-unsanitized-hook' }
+    await expect(prepublishLib(options)).resolves.toMatchSnapshot()
+  })
+
+  it('check for undefined mandatory options', async () => {
+    const options = { ...optionsMock, prepublishHook: './test/__mocks__/prepublish-missing-options-hook' }
+    await expect(prepublishLib(options)).rejects.toThrowErrorMatchingSnapshot()
+  })
+})

--- a/test/travis.spec.js
+++ b/test/travis.spec.js
@@ -2,11 +2,16 @@
 const path = require('path')
 
 const publishLib = require('../lib/publish')
+const prepublishLib = require('../lib/prepublish')
 
 const mockAppDir = path.join(__dirname, 'mockApp')
 
 jest.mock('../lib/publish', () => jest.fn((options, finishCallback) => {
   finishCallback()
+}))
+
+jest.mock('../lib/prepublish', () => jest.fn(options => {
+  return Object.assign({}, options, { sha256Sum: 'fakeshasum5644545'})
 }))
 
 const commons = {
@@ -119,9 +124,9 @@ describe('Travis publishing script', () => {
     })
   })
 
-  it('should throw an error if the token is missing', () => {
-    expect(() => travisScript(
+  it('should throw an error if the token is missing', async () => {
+    await expect(travisScript(
       getOptions(), jest.fn())
-    ).toThrowErrorMatchingSnapshot()
+    ).rejects.toThrowErrorMatchingSnapshot()
   })
 })


### PR DESCRIPTION
This PR allow to pass a new option --prepublish to cozyPublish. This option value must be a script path. This script must behave as a hook, i.e. get publish options in parameter and return new values for them. As this script is asynchronous, it can handles stuff like uploading to a dedicated server (i.e downcloud.cozycloud.cc for example).

From the updated README :

##### `--prepublish <script_path>`

Specify custom prepublish hook to manage how the app archive is generated and uploaded. The script must export a asynchronous function wich have the following signature:
```js
module.exports = async ({
  appBuildUrl,
  appSlug,
  appType,
  appVersion,
  buildCommit,
  registryUrl,
  registryEditor,
  registryToken,
  spaceName
}) => {
 // ...
}
```

This function must return an object containing the same options given in parameter, which can have been updated. For example, you may specifiy a new appBuildUlr in the hook. Here's a description of the different options:

|Options|Description|
|-|-|
| `appBuildUrl` | The url where the build can be retrieved. For example, `http://github.com/cozy/cozy-foo/archives/cozy-foo.tar.gz`|
| `appSlug` | The slug of the application, as defined in the manifest. Should not be mutated |
| `appType` | `webapp` or `konnector` |
| `appVersion` | App version, as defined in the manifest. Should not be mutated. |
| `buildCommit` | sha of the commit, should not be mutated. |
| `registryUrl` | URL of the Cozy registry, should not be mutated. |
| `registryEditor` | Editor as it appears in the Cozy registry. |
| `registryToken` | Registry Token. See [registry documentation](https://docs.cozy.io/en/cozy-stack/registry-publish/). Should not be mutated. |
| `spaceName` | Space name in the Cozy registry. |