### PR TITLE
Get last commit in manual script when no buildCommit is provided

### DIFF
--- a/lib/manual.js
+++ b/lib/manual.js
@@ -6,6 +6,7 @@ const prompt = require('prompt')
 const colorize = require('../utils/colorize')
 const getManifestAsObject = require('../utils/getManifestAsObject')
 const constants = require('./constants')
+const spawn = require('./spawn')
 
 const {
   DEFAULT_REGISTRY_URL,

--- a/lib/manual.js
+++ b/lib/manual.js
@@ -58,6 +58,26 @@ async function manualPublish ({
     throw new Error('The --build-url option is required for the manual mode. Publishing failed.')
   }
 
+  if (!buildCommit) {
+    const gitProcess = spawn.sync(
+      'git',
+      [
+        'rev-parse',
+        'HEAD'
+      ],
+      {
+        stdio: verbose ? 'inherit' : 'pipe'
+      }
+    )
+
+    if (gitProcess.status === 0) {
+      // remove also the ending line break
+      buildCommit = gitProcess.stdout.toString().replace(/\r?\n|\r/g, '')
+    } else {
+      console.error(`↳ ⚠️  Cannot get last commit sha : ${error.message}`)
+    }
+  }
+
   const promptProperties = [
     {
       name: 'confirm',


### PR DESCRIPTION
This PR get the last commit from HEAD when no `buildCommit` is provided.