### PR TITLE
Avoid process.exit(1) in publish.js and throw exceptions instead

### DIFF
--- a/cozy-app-publish.js
+++ b/cozy-app-publish.js
@@ -44,17 +44,22 @@ const program = new commander.Command(pkg.name)
   })
   .parse(process.argv)
 
-publishApp({
-  token: program.token,
-  buildDir: program.buildDir,
-  buildUrl: program.buildUrl,
-  buildCommit: program.buildCommit,
-  manualVersion: program.manualVersion,
-  prepublishHook: program.prepublish,
-  registryUrl: program.registryUrl,
-  space: program.space,
-  verbose: program.verbose
-})
+try {
+  publishApp({
+    token: program.token,
+    buildDir: program.buildDir,
+    buildUrl: program.buildUrl,
+    buildCommit: program.buildCommit,
+    manualVersion: program.manualVersion,
+    prepublishHook: program.prepublish,
+    registryUrl: program.registryUrl,
+    space: program.space,
+    verbose: program.verbose
+  })
+} catch (error) {
+  console.log(colorize.red(`Publishing failed: ${e.message}`))
+  process.exit(1)
+}
 
 function _getPublishMode () {
   if (process.env.TRAVIS === 'true') {

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -32,11 +32,7 @@ module.exports = ({
       .then(body => {
         if (resp.status === 409) { // application already exist -> don't throw
           console.log(`Not published: ${resp.status} ${resp.statusText}: ${body.error}`)
-          if (typeof finishCallback === 'function') {
-            return finishCallback(resp)
-          } else {
-            process.exit(0)
-          }
+          return (typeof finishCallback === 'function') && finishCallback(resp)
         }
         throw new Error(`${resp.status} ${resp.statusText}: ${body.error}`)
       })
@@ -44,16 +40,13 @@ module.exports = ({
     console.log(colorize.blue('Application published!'))
     if (typeof finishCallback === 'function') {
       return finishCallback()
-    } else {
-      process.exit(0)
     }
   })
   .catch(e => {
-    console.log(colorize.red(`Publishing failed: ${e.message}`))
     if (typeof finishCallback === 'function') {
       return finishCallback(e)
     } else {
-      process.exit(1)
+      throw e
     }
   })
 }


### PR DESCRIPTION
As `publish.js` was calling `process.exit(1)`, it caused side effects when calling only `manual.js` from an external node script (for example, the `publish.js` script in cozy-banks), making the manual publish failing but keeping the whole process succeed. It was generating "false positive" build in Travis, where all was green and cool but in reality build has failed.